### PR TITLE
fix 'storage size isn’t known'

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <time.h>
+#include <sys/time.h>
 #ifdef WIN32
     #include <winsock2.h>
     typedef int socklen_t;


### PR DESCRIPTION
the error occur when building ipk of OpenWrt trunk
reference: http://stackoverflow.com/questions/8620478/c-error-storage-size-isn-t-known